### PR TITLE
Add Makefile to build and run shell program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Compiler and flags for building the shell
+CC := gcc
+CPPFLAGS := -D_POSIX_C_SOURCE=200809L
+CFLAGS := -Wall -Wextra -pedantic -std=c11
+
+# Default target builds the shell executable
+all: shell
+
+shell: shell.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $<
+
+run: shell
+	./shell
+
+clean:
+	rm -f shell
+
+.PHONY: all run clean


### PR DESCRIPTION
## Summary
- add a repository-level Makefile with documented compiler flags and a default build target for the shell executable
- provide run and clean utility targets for executing the shell and removing the compiled binary

## Testing
- make clean
- make
- make run <<'EOF'
exit
EOF

------
https://chatgpt.com/codex/tasks/task_e_68d889fd2ce08325a698420ebdbcef08